### PR TITLE
Update core.py

### DIFF
--- a/thoth/package_extract/core.py
+++ b/thoth/package_extract/core.py
@@ -48,10 +48,10 @@ def extract_buildlog(input_text: str) -> typing.List[dict]:
 def extract_image(image_name: str, timeout: int = None, *, registry_credentials: str = None,
                   tls_verify: bool=True) -> dict:
     """Extract dependencies from an image."""
-    """Begin the timer for when the job starts"""
+    #Setting up the prometheus registry and the Gauge metric
     prometheus_registry = CollectorRegistry()
-    metric_analyzer_job = Gauge('package_extract_time','Runtime of package extract job', registry=prometheus_registry)
-    
+    metric_analyzer_job = Gauge('package_extract_time', 'Runtime of package extract job', registry=prometheus_registry)
+    #Begins a timer to record the running time of the job
     with metric_analyzer_job.time(), tempfile.TemporaryDirectory() as dir_path:
         image_name = quote(image_name)
         download_image(
@@ -61,7 +61,6 @@ def extract_image(image_name: str, timeout: int = None, *, registry_credentials:
             registry_credentials=registry_credentials or None,
             tls_verify=tls_verify
         )
-        
         rootfs_path = os.path.join(dir_path, 'rootfs')
         layers = construct_rootfs(dir_path, rootfs_path)
 
@@ -71,7 +70,7 @@ def extract_image(image_name: str, timeout: int = None, *, registry_credentials:
    push_gateway = os.getenv('PROMETHEUS_PUSH_GATEWAY', 'pushgateway:9091')
    if push_gateway:
         try:
-            pushadd_to_gateway(push_gateway, job='package-extract-runtime',registry=prometheus_registry)
+            pushadd_to_gateway(push_gateway, job='package-extract-runtime', registry=prometheus_registry)
         except Exception as e:
             _LOGGER.exception('An error occurred pushing the metrics: {}'.format(str(e)))
             

--- a/thoth/package_extract/core.py
+++ b/thoth/package_extract/core.py
@@ -50,9 +50,8 @@ def extract_buildlog(input_text: str) -> typing.List[dict]:
 def extract_image(image_name: str, timeout: int = None, *, registry_credentials: str = None,
                   tls_verify: bool=True) -> dict:
     """Extract dependencies from an image."""
-    try:
-         """Begin the timer for when the job starts"""
-        with _METRIC_ANALYZER_JOB.time():
+    """Begin the timer for when the job starts"""
+    with _METRIC_ANALYZER_JOB.time():
             image_name = quote(image_name)
             with tempfile.TemporaryDirectory() as dir_path:
                 download_image(
@@ -63,19 +62,14 @@ def extract_image(image_name: str, timeout: int = None, *, registry_credentials:
                     tls_verify=tls_verify
                 )
 
-            rootfs_path = os.path.join(dir_path, 'rootfs')
-            layers = construct_rootfs(dir_path, rootfs_path)
+                rootfs_path = os.path.join(dir_path, 'rootfs')
+                layers = construct_rootfs(dir_path, rootfs_path)
 
-            result = run_analyzers(rootfs_path)
-            result['layers'] = layers
+                result = run_analyzers(rootfs_path)
+                result['layers'] = layers
 
-            return result
-     except: pass
-     else:
-            """If the job was unsuccessful the time is recorded for the last successful job"""
-        last_success = Gauge('package_extract_last_success_time','Unix time the package extract job last succeeded', registry=prometheus_registry)
-        last_success.set_to_current_time()
-     finally:
+                return result
+        
         push_gateway = os.getenv('PROMETHEUS_PUSH_GATEWAY', 'pushgateway:9091')
         if push_gateway:
             try:


### PR DESCRIPTION
Added the Prometheus Gauge metric to analyze the run time of each package extract job.

1. A timer is started once the job is initialized
2. The metrics is pushed using 'pushadd_to_gateway' rather than 'push_to_gateway' so that a failed run won’t overwrite the value of a previous success.
3. 'package_extract_time' is always pushed, so it can be graphed over time.