### PR TITLE
Bundle skopeo executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'thoth.package_extract.handlers',
     ],
     package_data={
-        'thoth-package_extract': 'thoth/package_extract/bin/skopeo'
+        'thoth-package-extract': os.path.join('thoth', 'package_extract', 'bin', 'skopeo')
     },
     zip_safe=False,
     install_requires=get_requirements(),

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
         'thoth.package_extract',
         'thoth.package_extract.handlers',
     ],
+    package_data={
+        'thoth-package_extract': 'thoth/package_extract/bin/skopeo'
+    },
     zip_safe=False,
     install_requires=get_requirements(),
     author='Fridolin Pokorny',

--- a/thoth/package_extract/image.py
+++ b/thoth/package_extract/image.py
@@ -37,6 +37,12 @@ _LOGGER = logging.getLogger(__name__)
 
 _MERCATOR_BIN = os.getenv('MERCATOR_BIN', 'mercator')
 _MERCATOR_HANDLERS_YAML = os.getenv('MERCATOR_HANDLERS_YAML', '/usr/share/mercator/handlers.yml')
+_HERE_DIR = os.path.dirname(os.path.abspath(__file__))
+_SKOPEO_EXEC_PATH = os.getenv('SKOPEO_EXEC_PATH', os.path.join(_HERE_DIR, 'bin/skopeo'))
+
+
+assert os.path.isfile(_SKOPEO_EXEC_PATH) and os.access(_SKOPEO_EXEC_PATH, os.X_OK), \
+    f"skopeo executable not found in path: '{_SKOPEO_EXEC_PATH}'"
 
 
 def _normalize_mercator_output(path: str, output: dict) -> dict:
@@ -270,7 +276,7 @@ def download_image(image_name: str, dir_path: str, timeout: int = None, registry
     """Download an image to dir_path."""
     _LOGGER.debug("Downloading image %r", image_name)
 
-    cmd = 'skopeo copy '
+    cmd = f'{_SKOPEO_EXEC_PATH} copy '
     if not tls_verify:
         cmd += '--src-tls-verify=false '
     if registry_credentials:
@@ -278,7 +284,7 @@ def download_image(image_name: str, dir_path: str, timeout: int = None, registry
 
     cmd += 'docker://{} dir:/{}'.format(quote(image_name), quote(dir_path))
     stdout = run_command(cmd, timeout=timeout).stdout
-    _LOGGER.debug("skopeo stdout: %s", stdout)
+    _LOGGER.debug(f"{_SKOPEO_EXEC_PATH} stdout: %s", stdout)
 
 
 def run_analyzers(path: str, timeout: int = None) -> dict:

--- a/thoth/package_extract/image.py
+++ b/thoth/package_extract/image.py
@@ -38,11 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 _MERCATOR_BIN = os.getenv('MERCATOR_BIN', 'mercator')
 _MERCATOR_HANDLERS_YAML = os.getenv('MERCATOR_HANDLERS_YAML', '/usr/share/mercator/handlers.yml')
 _HERE_DIR = os.path.dirname(os.path.abspath(__file__))
-_SKOPEO_EXEC_PATH = os.getenv('SKOPEO_EXEC_PATH', os.path.join(_HERE_DIR, 'bin/skopeo'))
-
-
-assert os.path.isfile(_SKOPEO_EXEC_PATH) and os.access(_SKOPEO_EXEC_PATH, os.X_OK), \
-    f"skopeo executable not found in path: '{_SKOPEO_EXEC_PATH}'"
+_SKOPEO_EXEC_PATH = os.getenv('SKOPEO_EXEC_PATH', os.path.join(_HERE_DIR, 'bin', 'skopeo'))
 
 
 def _normalize_mercator_output(path: str, output: dict) -> dict:
@@ -284,7 +280,7 @@ def download_image(image_name: str, dir_path: str, timeout: int = None, registry
 
     cmd += 'docker://{} dir:/{}'.format(quote(image_name), quote(dir_path))
     stdout = run_command(cmd, timeout=timeout).stdout
-    _LOGGER.debug(f"{_SKOPEO_EXEC_PATH} stdout: %s", stdout)
+    _LOGGER.debug("%s stdout: %s", _SKOPEO_EXEC_PATH, stdout)
 
 
 def run_analyzers(path: str, timeout: int = None) -> dict:


### PR DESCRIPTION
Module image.py uses skopeo, which is not available as python package
and has to be run as binary (or installed via RPM).

This is an obstacle for s2i and causes errors in example jupyter notebooks.

path to executable is provided via environment variable
`SKOPEO_EXEC_PATH` and defaults to 'thoth/package_extract/bin/skopeo'

[[skopeo]](https://www.google.com/search?q=skopeo&ie=utf-8&oe=utf-8&client=firefox-b-ab)

Signed-off-by: Marek Cermak <macermak@redhat.com>

new file:   thoth/package_extract/bin/skopeo
modified:   setup.py
modified:   thoth/package_extract/image.py