### PR TITLE
Minor rework of system symbols gathering

### DIFF
--- a/thoth/package_extract/image.py
+++ b/thoth/package_extract/image.py
@@ -337,14 +337,15 @@ def _ld_config_entries(path: str) -> Generator[str, None, None]:
                         if not line.startswith("/"):
                             line = os.path.join("etc", line)
 
-                    if line.startswith("/"):
-                        # Discard leading / to correctly handle paths relative to the extracted container path.
-                        line = line[1:]
-
                     if not line:
                         continue
 
-                    for entry_path in glob.glob(os.path.join(path, relative_path, line)):
+                    if line.startswith("/"):
+                        to_glob = os.path.join(path, line[1:])
+                    else:
+                        to_glob = os.path.join(path, relative_path, line)
+
+                    for entry_path in glob.glob(to_glob):
                         if os.path.isdir(entry_path):
                             yield line
                         elif os.path.isfile(entry_path):

--- a/thoth/package_extract/image.py
+++ b/thoth/package_extract/image.py
@@ -324,10 +324,11 @@ def _ld_config_symbols(result: dict, path: str) -> None:
     try:
         with cwd(os.path.join(path, "etc/")), open("ld.so.conf", "r") as f:
             for line in f.readlines():
-                if not line.startswith("include "):
-                    continue
+                if line.startswith("include "):
+                    line = line[len("include "):]
 
-                line = line[len("include "):]
+                if not line:
+                    continue
 
                 # Both relative and absolute will work:
                 #   os.path.join("/foo", "bar") == "/foo/bar"

--- a/thoth/package_extract/image.py
+++ b/thoth/package_extract/image.py
@@ -288,6 +288,7 @@ def _run_apt_cache_show(
 
 def _get_lib_dir_symbols(result: dict, container_path: str, path: str) -> None:
     """Get library symbols from a directory."""
+    path = path[1:] if path.startswith("/") else path
     for so_file_path in glob.glob(os.path.join(container_path, path, "*.so*")):
         # We grep for '0 A' here because all exported symbols are outputted by nm like:
         # 00000000 A GLIBC_1.x or:


### PR DESCRIPTION
Fixes: #269 

- fix missing imports
- comment out gathering based on env variable LD_PRELOAD instead of gathering based on `ld.so.conf`
- adjust output so that it produces exported symbols per so file