### PR TITLE
Fix: use dockerfile strategy for package-extract build

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -3,8 +3,8 @@ check:
   - thoth-precommit
   - thoth-pytest-py38
 build:
-  base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:latest
-  build-stratergy: Source
+  build-stratergy: Dockerfile
+  dockerfile-path: Dockerfile
   registry: quay.io
   registry-org: thoth-station
   registry-project: package-extract


### PR DESCRIPTION
Fix: use dockerfile strategy for package-extract build
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

 It is currently built by the pipeline as an s2i application, but is a docker build.
