### PR TITLE
upgrade the base image from f28 to f32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:32
 
 ENV PATH=$HOME/.local/bin/:$PATH \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
upgrade the base image from f28 to f32
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

fedora 28 image is not longer available on fedora registry.

