### PR TITLE
Moving Maya to emeritus_approver + add myself

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,13 +3,14 @@
 approvers:
   - kpostoffice
   - harshad16
-  - mayacostantini
+  - VannTen
   - sesheta
 
 emeritus_approvers:
   - fridex
+  - mayacostantini
 
 reviewers:
   - kpostoffice
   - harshad16
-  - mayacostantini
+  - VannTen


### PR DESCRIPTION
Only two approvers besides sesheta looks like a bit of a bottleneck.
Not much activity here so I can as well add myself.
