### PR TITLE
Disable the pipfile -> requirements.txt kebechet manager

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -11,7 +11,6 @@ runtime_environments:
     recommendation_type: latest
 
 managers:
-  - name: pipfile-requirements
   - name: update
     configuration:
       labels: [bot]


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/package-extract/pull/506#issuecomment-1415894771

#499 

## Description

The repo doesn't need `requirements.txt` anymore, so this PR disables the corresponding kebechet manager

/cc @VannTen 
